### PR TITLE
Deploy to serverless

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,3 +31,6 @@ jobs:
         
             - name: Build Docker image and push to Google Artifact Registry
               run: gcloud builds submit --tag us-central1-docker.pkg.dev/notely-427300/notely-ar-repo/notely:latest .
+
+            - name: Deploy to Cloud Run
+              run: gcloud run deploy notely --image us-central1-docker.pkg.dev/notely-427300/notely-ar-repo/notely:latest --region us-central1 --allow-unauthenticated --project notely-427300 --max-instances=4

--- a/static/index.html
+++ b/static/index.html
@@ -7,7 +7,7 @@
 </head>
 
 <body class="section">
-    <h1>Notely</h1>
+    <h1>Welcome to Notely</h1>
 
     <div id="userCreationContainer" class="section">
         <input id="nameField" type="text" placeholder="Enter your name">


### PR DESCRIPTION
Cloud Run is GCP's serverless option. We intended to automatically deploy when commits are merged into main